### PR TITLE
Avoid powerapps checker strict equality issues

### DIFF
--- a/code/clientjs/webpack.prod.js
+++ b/code/clientjs/webpack.prod.js
@@ -3,4 +3,19 @@ const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 module.exports = merge(common, {
   mode: "production",
+  optimization: {
+    minimize: true,
+    minimizer: [
+        new TerserPlugin({
+            terserOptions: {
+                compress: {
+                    // Power Apps Solution Checker will complain if strict equality operators
+                    // are optimised, rule: web-use-strict-equality-operators
+                    // see https://docs.microsoft.com/en-us/powerapps/maker/data-platform/use-powerapps-checker#best-practice-rules-used-by-solution-checker
+                    comparisons: false
+                }
+            }
+        })
+    ]
+  }  
 });


### PR DESCRIPTION
Webpack production mode can optimise === into ==, which causes the power apps solution checker to complain.   This PR disables the optimisation for this specific area.

I'm seeing between 0.3% and 1.8% increase in bundle size due to turning off this optimisation.

Alternatives are:
* Exclude the specific rule when running solution checker - which is only possible when running solution checker via Powershell, and not (yet) possible with the standard Power Platform Build Tools Azure DevOps tasks or maker portal
* Ignore errors :(


